### PR TITLE
fix metadata selector and id of metadata-url element

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -58,7 +58,7 @@ img {
   opacity: 0.75;
 }
 
-#metadata {
+li[id$="metadata"] {
   background-color: #f2fafa;
 }
 

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -62,7 +62,7 @@ li[id$="metadata"] {
   background-color: #f2fafa;
 }
 
-#metadata-url {
+a[id$="metadata-url"] {
   /* .results .seperator .result-button-group .result-button.fulltext */
   background: url('https://katalog.slub-dresden.de/typo3conf/ext/slub_katalog_beta/Resources/Public/Images/directlink.svg') no-repeat center center;
   background-size: 80% 80%;
@@ -78,7 +78,7 @@ li[id$="metadata"] {
 
 @media (min-width: 992px) {
   /* .results .seperator .result-button-group .result-button */
-  #metadata-url {
+  a[id$="metadata-url"] {
     -webkit-transition: all 150ms cubic-bezier(0.16, -0.5, 0.14, 3);
     -moz-transition: all 150ms cubic-bezier(0.16, -0.5, 0.14, 3);
     -ms-transition: all 150ms cubic-bezier(0.16, -0.5, 0.14, 3);
@@ -86,7 +86,7 @@ li[id$="metadata"] {
     transition: all 150ms cubic-bezier(0.16, -0.5, 0.14, 3);
     transform: scale(1);
   }
-  #metadata-url:hover {
+  a[id$="metadata-url"]:hover {
     transform: scale(1.4);
   }
 }

--- a/assets/js/build.js
+++ b/assets/js/build.js
@@ -78,7 +78,7 @@ function handleMetadata (item) {
   date.innerHTML = details[0].date;
   li.appendChild(date);
   var url = createNode('a');
-  url.id = 'metadata-url';
+  url.id = item.id.concat('_metadata-url');
   url.title = 'Link zur Online-Ressource';
   url.href = details[0].url;
   url.target = '_blank';


### PR DESCRIPTION
after changing the way ids are generated for list elements containing metadata (see #30), the css selector no longer matched. this is fixed in the first commit. the second commit ensures a unique id is created for every url displayed as part of the metadata and changes the css accordingly.