### PR TITLE
Added back navigation and shortened text

### DIFF
--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -18,6 +18,70 @@
   }
 }
 
+.displayBreadcrumb ol.rootline{
+    position:relative;
+    margin-top:12px;
+    padding:0;
+    opacity:.5;
+    color:#666;
+    list-style-type:none;
+    font-size:12px;
+    line-height:1.4
+}
+
+.displayBreadcrumb ol.rootline:hover{
+    opacity:1
+}
+
+.displayBreadcrumb ol.rootline li{
+    position:relative;
+    font-weight:normal;
+    padding:0 15px 0 0;
+    display:inline-block
+}
+
+.displayBreadcrumb ol.rootline li a{
+    color:#666;
+    font-weight:normal;
+    font-family:'VisSlabBold',Georgia,Times,serif
+}
+
+.displayBreadcrumb ol.rootline li:before{
+    content:none
+}
+
+.displayBreadcrumb ol.rootline li:after{
+    position:absolute;
+    top:50%;
+    right:5px;
+    width:4px;
+    height:4px;
+    margin-top:-2px;
+    border:solid #666;
+    border-width:1px 1px 0 0;
+    -webkit-transform:rotate(45deg);
+    transform:rotate(45deg);
+    content:" "
+}
+
+.displayBreadcrumb ol.rootline li:last-child{
+    padding:0
+}
+
+.displayBreadcrumb ol.rootline li:last-child:after{
+    content:none
+}
+
+.displayBreadcrumb ol{
+    margin:1.4em 0;
+    list-style:none;
+    counter-reset:countlii
+}
+
+.displayBreadcrumb .rootline a{
+    text-decoration:none
+}
+
 .displayText {
   line-height: 160%; 
 }

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -113,3 +113,9 @@ a[id$="metadata-url"] {
     width: 140px;
   }
 }
+
+@media (min-width: 351px) and (max-width: 390px) {
+#tu {
+    display: none;
+  }
+}

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -111,4 +111,5 @@ a[id$="metadata-url"] {
 @media (max-width: 350px) {
 #tu {
     width: 140px;
+  }
 }

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -19,8 +19,7 @@
 }
 
 .displayText {
-  line-height: 160%;
-  
+  line-height: 160%; 
 }
 
 .displayText > h1 {

--- a/assets/css/layout.css
+++ b/assets/css/layout.css
@@ -2,6 +2,22 @@
     background: rgba(153,204,221,0.6)
 }
 
+@media (min-width: 375px) {
+  .navbar-resultlist #resultOptions {
+    height: 0px !important;
+  }
+}
+
+.navbar-resultlist .resultCount {
+  height: 0 !important;
+}
+
+@media (min-width: 768px) {
+  .navbar-resultlist .resultCount {
+    margin: 0 !important;
+  }
+}
+
 .displayText {
   line-height: 160%;
   

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
                 <ol class="rootline">
                     <li><a href="https://www.slub-dresden.de/" title="SLUB Dresden">SLUB Dresden</a>::after</li>
                     <li><a href="https://www.slub-dresden.de/mitmachen/" title="Mitmachen">Mitmachen</a>::after</li>
-                    <li><a href="https://www.slub-dresden.de/open-educational-resources/" title="Open Educational Resources">Open Educational Resources</a>::after</li>
+                    <li><a href="https://www.slub-dresden.de/mitmachen/open-educational-resources/" title="Open Educational Resources">Open Educational Resources</a>::after</li>
                     <li>OER-Display</li>
                 </ol>
                 <h1>OER-Display</h1>

--- a/index.html
+++ b/index.html
@@ -44,13 +44,15 @@
             <div class="col-md-12 navbar-resultlist">
               <div class="resultCount"></div>
               <div id="resultOptions"></div>
-              <div class="displayText">
+              <div class="displayBreadcrumb">
                 <ol class="rootline">
                   <li><a href="https://www.slub-dresden.de/" title="SLUB Dresden">SLUB Dresden</a></li>
                   <li><a href="https://www.slub-dresden.de/mitmachen/" title="Mitmachen">Mitmachen</a></li>
                   <li><a href="https://www.slub-dresden.de/mitmachen/open-educational-resources/" title="Open Educational Resources">Open Educational Resources</a></li>
                   <li>OER-Display</li>
                 </ol>
+              </div>
+              <div class="displayText">
                 <h1>OER-Display</h1>
                 <p>Im OER-Display stellen wir prototypische und besonders anschauliche OER vor. Ziel ist es, die Bandbreite der technischen und didaktischen Möglichkeiten digitaler Lehre zu illustrieren und Lehrende bei der Erstellung von OER zu inspirieren.</p>
                 <p>Das Portfolio an hier präsentierten OER wird laufend ergänzt und soll sukzessive um offene Lehr- und Lernmaterialien aus anderen Bereichen der TU Dresden erweitert werden.</p>

--- a/index.html
+++ b/index.html
@@ -46,9 +46,9 @@
               <div id="resultOptions"></div>
               <div class="displayText">
                 <ol class="rootline">
-                    <li><a href="https://www.slub-dresden.de/" title="SLUB Dresden">SLUB Dresden</a>::after</li>
-                    <li><a href="https://www.slub-dresden.de/mitmachen/" title="Mitmachen">Mitmachen</a>::after</li>
-                    <li><a href="https://www.slub-dresden.de/mitmachen/open-educational-resources/" title="Open Educational Resources">Open Educational Resources</a>::after</li>
+                    <li><a href="https://www.slub-dresden.de/" title="SLUB Dresden">SLUB Dresden</a></li>
+                    <li><a href="https://www.slub-dresden.de/mitmachen/" title="Mitmachen">Mitmachen</a></li>
+                    <li><a href="https://www.slub-dresden.de/mitmachen/open-educational-resources/" title="Open Educational Resources">Open Educational Resources</a></li>
                     <li>OER-Display</li>
                 </ol>
                 <h1>OER-Display</h1>

--- a/index.html
+++ b/index.html
@@ -45,9 +45,14 @@
               <div class="resultCount"></div>
               <div id="resultOptions"></div>
               <div class="displayText">
+                <ol class="rootline">
+                    <li><a href="https://www.slub-dresden.de/" title="SLUB Dresden">SLUB Dresden</a>::after</li>
+                    <li><a href="https://www.slub-dresden.de/mitmachen/" title="Mitmachen">Mitmachen</a>::after</li>
+                    <li><a href="https://www.slub-dresden.de/open-educational-resources/" title="Open Educational Resources">Open Educational Resources</a>::after</li>
+                    <li>OER-Display</li>
+                </ol>
                 <h1>OER-Display</h1>
-                <p>Offene, das heißt frei zugängliche und nachnutzbare, Lehr- und Lernmaterialien (Open Educational Resources, OER) sind für Lernende und Lehrende gleichermaßen attraktiv. Lernenden ermöglichen sie orts- und zeitunabhängig Zugriff auf Lerninhalte und damit einen Zugang zu Wissen. Lehrende unterstützen sie bei einer effizienten Erstellung hochqualitativer Unterichtsmaterialien und tragen zur professionellen Sichtbarkeit bei.</p>
-                <p>Das OER-Display ist aus einer gemeinsamen Initiative des <a href="https://tu-dresden.de/gsw/">Bereichs Geistes- und Sozialwissenschaften</a>, des <a href="https://tu-dresden.de/tu-dresden/organisation/rektorat/prorektor-bildung/zill">Zentrums für Interdisziplinäres Lehren und Lernen (ZiLL)</a> und der <a href="https://www.slub-dresden.de/startseite/">Sächsischen Landesbibliothek – Staats- und Universitätsbibliothek Dresden (SLUB)</a> zur Förderung von OER an der TU Dresden hervorgegangen. Im OER-Display stellen wir prototypische und besonders anschauliche OER vor. Ziel ist es, die Bandbreite der technischen und didaktischen Möglichkeiten digitaler Lehre zu illustrieren und Lehrende bei der Erstellung von OER zu inspirieren.</p>
+                <p>Im OER-Display stellen wir prototypische und besonders anschauliche OER vor. Ziel ist es, die Bandbreite der technischen und didaktischen Möglichkeiten digitaler Lehre zu illustrieren und Lehrende bei der Erstellung von OER zu inspirieren.</p>
                 <p>Das Portfolio an hier präsentierten OER wird laufend ergänzt und soll sukzessive um offene Lehr- und Lernmaterialien aus anderen Bereichen der TU Dresden erweitert werden.</p>
                 <p>Wenn Sie Interesse haben, Ihre eigenen OER hier zur Verfügung zu stellen, <a href="https://www.slub-dresden.de/service/wissensbar/thema/gbList/204/#book-me-now">spezifische Beratung</a> zu OER wünschen oder einfach nur Interesse am Thema haben, kontaktieren Sie uns unter <a href="mailto:oer@slub-dresden.de">oer@slub-dresden.de</a>.</p>
               </div>

--- a/index.html
+++ b/index.html
@@ -46,10 +46,10 @@
               <div id="resultOptions"></div>
               <div class="displayText">
                 <ol class="rootline">
-                    <li><a href="https://www.slub-dresden.de/" title="SLUB Dresden">SLUB Dresden</a></li>
-                    <li><a href="https://www.slub-dresden.de/mitmachen/" title="Mitmachen">Mitmachen</a></li>
-                    <li><a href="https://www.slub-dresden.de/mitmachen/open-educational-resources/" title="Open Educational Resources">Open Educational Resources</a></li>
-                    <li>OER-Display</li>
+                  <li><a href="https://www.slub-dresden.de/" title="SLUB Dresden">SLUB Dresden</a></li>
+                  <li><a href="https://www.slub-dresden.de/mitmachen/" title="Mitmachen">Mitmachen</a></li>
+                  <li><a href="https://www.slub-dresden.de/mitmachen/open-educational-resources/" title="Open Educational Resources">Open Educational Resources</a></li>
+                  <li>OER-Display</li>
                 </ol>
                 <h1>OER-Display</h1>
                 <p>Im OER-Display stellen wir prototypische und besonders anschauliche OER vor. Ziel ist es, die Bandbreite der technischen und didaktischen Möglichkeiten digitaler Lehre zu illustrieren und Lehrende bei der Erstellung von OER zu inspirieren.</p>


### PR DESCRIPTION
This PR aims at integrating the OER display more smoothly into the SLUB website. Not sure whether the back navigation approach copied from the SLUB website will work without further additions to the CSS.

@herreio Could you pls. have a look? Also: Did you see how @gnuj implemented the cover-information switch in the OER display preview at the new OER page? It is pretty neat how the cover shifting is eliminated using the "reversement" effect. Can we do something similar?